### PR TITLE
add hide default chrome scrollbar

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -72,6 +72,11 @@ render: function() {
     border-radius: 3px;
     background: #ccc;
 }
+/* hide default chrome scrollbar */
+.scroller::-webkit-scrollbar {
+    width: 0;
+    height: 0;
+}
 ```
 
 **API**


### PR DESCRIPTION
spent time to figure what's difference with baron.js demo page. and finally found.
