### PR TITLE
update baron version

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,6 @@
   "author": "Diokuz",
   "license": "ISC",
   "dependencies": {
-    "baron": "2.1.1"
+    "baron": "2.2.8"
   }
 }


### PR DESCRIPTION
Server-side rendering is broken in baron 2.1.1:

```
$ node
> require('react-baron')
ReferenceError: window is not defined
    at Object.<anonymous> (/Users/lastw/dev/online4/node_modules/react-baron/node_modules/baron/baron.min.js:1:8819)
    at Module._compile (module.js:570:32)
    at Object.Module._extensions..js (module.js:579:10)
    at Module.load (module.js:487:32)
    at tryModuleLoad (module.js:446:12)
    at Function.Module._load (module.js:438:3)
    at Module.require (module.js:497:17)
    at require (internal/module.js:20:19)
    at Object.<anonymous> (/Users/lastw/dev/online4/node_modules/react-baron/index.js:4:13)
    at Module._compile (module.js:570:32)
```