### PR TITLE
const shouldn't present in dist/es5.js

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -24,7 +24,7 @@ module.exports = {
             loader: 'string-replace-loader',
             options: {
               search: 'import s from \'./styles.css\'',
-              replace: `const s = ${JSON.stringify(defaultClassNames)}`,
+              replace: `var s = ${JSON.stringify(defaultClassNames)}`,
             },
           },
           {


### PR DESCRIPTION
Safari 9 throws the error:
SyntaxError: Unexpected keyword 'const'. Const declarations are not supported in strict mode.